### PR TITLE
Support for RequireJS and compatibility with require-css

### DIFF
--- a/src/main/resources/webjars-requirejs.js
+++ b/src/main/resources/webjars-requirejs.js
@@ -1,7 +1,7 @@
 requirejs.config({
-  paths: { "fullcalendar": webjars.path("fullcalendar", "fullcalendar") },
+  paths: { 
+    "fullcalendar": webjars.path("fullcalendar", "fullcalendar"),
+    "fullcalendar-css": webjars.path("fullcalendar", "fullcalendar")  
+  },
   shim: { "fullcalendar": [ "jquery" ] }
 });
-
-
-    


### PR DESCRIPTION
The first commit allows to consider the official support for requireJS in Webjars since the 2.2.1-2 release.

The second commit allows require-css to retrieve the bootstrap CSS when the CSS is not in the root (that is the case here).
